### PR TITLE
Go 1.15: Convert int to string using rune()

### DIFF
--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -38,7 +38,7 @@ import (
 	"testing"
 )
 
-const binaryValue = string(128)
+const binaryValue = string(rune(128))
 
 func TestEncodeKeyValue(t *testing.T) {
 	for _, test := range []struct {


### PR DESCRIPTION
See https://github.com/golang/go/issues/32479

Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>